### PR TITLE
MALAWISUP-4202: Changed naming of exported reports

### DIFF
--- a/src/main/java/mw/gov/health/lmis/reports/service/JasperReportsViewService.java
+++ b/src/main/java/mw/gov/health/lmis/reports/service/JasperReportsViewService.java
@@ -74,9 +74,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.Date;
-
-import java.text.SimpleDateFormat;  
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -330,10 +327,16 @@ public class JasperReportsViewService {
           order.getFacility().getName()
       );
     } else {
-      //add date of generating report to the filename if it's not the order report
-      Date date = new Date();
-      SimpleDateFormat formatter = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss");
-      values.add(formatter.format(date));
+      values.add(params.get("program"));
+
+      if (params.containsKey("period")) {
+        values.add(params.get("period"));
+      } else if (params.containsKey("startDate") & params.containsKey("endDate")) {
+        values.add(params.get("startDate"));
+        values.add(params.get("endDate"));
+      } else if (params.containsKey("date")) {
+        values.add(params.get("date"));
+      }
     }
     // add all the parts to the filename and separate them by "_"
     for (Object value : values) {

--- a/src/main/resources/db/migration/20221124093822961__changed_template_parameter_names_to_lowercase.sql
+++ b/src/main/resources/db/migration/20221124093822961__changed_template_parameter_names_to_lowercase.sql
@@ -1,0 +1,23 @@
+UPDATE reports.jasper_templates
+SET name='program'
+WHERE id='55f3108a-fe41-4fce-a62a-fc0d3c9ce44e';
+
+UPDATE reports.jasper_templates
+SET name='geographicZone'
+WHERE id='726a82f3-c0d6-4d92-8f87-189abde5fcee';
+
+UPDATE reports.jasper_templates
+SET name='program'
+WHERE id='551795e8-5777-49c4-8e0c-b76bd65f8aed';
+
+UPDATE reports.jasper_templates
+SET name='period'
+WHERE id='1bb77e82-f27a-4069-a9da-4a86a7e4efea';
+
+UPDATE reports.jasper_templates
+SET name='geographicZone'
+WHERE id='25d3ddaf-ccc7-4d3a-ad07-4b168f2bb4bb';
+
+UPDATE reports.jasper_templates
+SET name='dueDays'
+WHERE id='3d1c018d-92d3-4286-9743-502dedf75f3d';

--- a/src/main/resources/db/migration/20221124093822961__changed_template_parameter_names_to_lowercase.sql
+++ b/src/main/resources/db/migration/20221124093822961__changed_template_parameter_names_to_lowercase.sql
@@ -1,23 +1,23 @@
-UPDATE reports.jasper_templates
+UPDATE reports.template_parameters
 SET name='program'
 WHERE id='55f3108a-fe41-4fce-a62a-fc0d3c9ce44e';
 
-UPDATE reports.jasper_templates
+UPDATE reports.template_parameters
 SET name='geographicZone'
 WHERE id='726a82f3-c0d6-4d92-8f87-189abde5fcee';
 
-UPDATE reports.jasper_templates
+UPDATE reports.template_parameters
 SET name='program'
 WHERE id='551795e8-5777-49c4-8e0c-b76bd65f8aed';
 
-UPDATE reports.jasper_templates
+UPDATE reports.template_parameters
 SET name='period'
 WHERE id='1bb77e82-f27a-4069-a9da-4a86a7e4efea';
 
-UPDATE reports.jasper_templates
+UPDATE reports.template_parameters
 SET name='geographicZone'
 WHERE id='25d3ddaf-ccc7-4d3a-ad07-4b168f2bb4bb';
 
-UPDATE reports.jasper_templates
+UPDATE reports.template_parameters
 SET name='dueDays'
 WHERE id='3d1c018d-92d3-4286-9743-502dedf75f3d';

--- a/src/test/java/mw/gov/health/lmis/reports/web/JasperReportsViewServiceTest.java
+++ b/src/test/java/mw/gov/health/lmis/reports/web/JasperReportsViewServiceTest.java
@@ -29,7 +29,7 @@ import static mw.gov.health.lmis.reports.web.ReportTypes.ORDER_REPORT;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
 @RunWith(MockitoJUnitRunner.class)
 public class JasperReportsViewServiceTest {
 
@@ -130,5 +130,57 @@ public class JasperReportsViewServiceTest {
 
     // then
     Assert.assertEquals("order_essential_meds_nov2017_chitipa_dho", filename);
+  }
+
+  @Test
+  public void shouldGetFilenameWithPeriodParameter() {
+    // given
+    JasperTemplate template = new JasperTemplate();
+    template.setName("Some report");
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("program", "Essential Meds");
+    params.put("period", "Jul2017");
+
+    // when
+    String filename = service.getFilename(template, params);
+
+    // then
+    Assert.assertEquals("some_report_essential_meds_jul2017", filename);
+  }
+
+  @Test
+  public void shouldGetFilenameWithStartDateAndEndDateParameter() {
+    // given
+    JasperTemplate template = new JasperTemplate();
+    template.setName("Some report");
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("program", "Essential Meds");
+    params.put("startDate", "2022-11-15");
+    params.put("endDate", "2022-11-24");
+
+    // when
+    String filename = service.getFilename(template, params);
+
+    // then
+    Assert.assertEquals("some_report_essential_meds_2022-11-15_2022-11-24", filename);
+  }
+
+  @Test
+  public void shouldGetFilenameWithSingleDateParameter() {
+    // given
+    JasperTemplate template = new JasperTemplate();
+    template.setName("Some report");
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("program", "Essential Meds");
+    params.put("date", "2022-11-15");
+
+    // when
+    String filename = service.getFilename(template, params);
+
+    // then
+    Assert.assertEquals("some_report_essential_meds_2022-11-15", filename);
   }
 }


### PR DESCRIPTION
Template parameter names needs to be started with lowercase letter to work properly on a backend side. 
The update clauses are all separated on purpose so migration will also be able to fix MALAWISUP-4181 problem with wrong inputs order in Reporting Rate Report.